### PR TITLE
Feature/handling inbound calls

### DIFF
--- a/lib/stealth/services/bandwidth/bandwidth_service_message.rb
+++ b/lib/stealth/services/bandwidth/bandwidth_service_message.rb
@@ -1,0 +1,15 @@
+module Stealth
+  module Services
+    module Bandwidth
+      class BandwidthServiceMessage < Stealth::ServiceMessage
+        attr_accessor :call_id,
+                      :call_url,
+                      :call_direction,
+                      :caller_number,
+                      :callee_number,
+                      :call_initiated_at
+
+      end
+    end
+  end
+end

--- a/lib/stealth/services/bandwidth/client.rb
+++ b/lib/stealth/services/bandwidth/client.rb
@@ -5,6 +5,7 @@ require 'http'
 require 'stealth/services/bandwidth/message_handler'
 require 'stealth/services/bandwidth/reply_handler'
 require 'stealth/services/bandwidth/setup'
+require 'stealth/services/bandwidth/bandwidth_service_message'
 
 module Stealth
   module Services


### PR DESCRIPTION
In this PR I created a dedicated 'BandwidthServiceMessage' to receive inbound call params

Inbound call params are the following:
```
:call_id,
:call_url,
:call_direction,
:caller_number,
:callee_number,
:call_initiated_at
```